### PR TITLE
fix: migrate old redux-persist stores to new architecture

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,10 +1,16 @@
 import { configureStore, getDefaultMiddleware } from 'redux-starter-kit';
+import { persistReducer, persistStore, createMigrate } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
+
 import rootReducer from 'reducers/rootReducer';
-import { persistReducer, persistStore } from 'redux-persist';
+import migrations from 'reducers/migrations';
+
+const MIGRATION_DEBUG = false;
 
 const persistConfig = {
   key: 'acquity',
+  version: 0,
+  migrate: createMigrate(migrations, { debug: MIGRATION_DEBUG }),
   storage
 };
 

--- a/src/reducers/ChatDux.js
+++ b/src/reducers/ChatDux.js
@@ -2,13 +2,15 @@ import { createSlice } from 'redux-starter-kit';
 import _orderBy from 'lodash/orderBy';
 import _findIndex from 'lodash/findIndex';
 
+export const initialState = {
+  chatRooms: [],
+  chatConversation: [],
+  chatRoomId: ''
+};
+
 const chat = createSlice({
   name: 'chat',
-  initialState: {
-    chatRooms: [],
-    chatConversation: [],
-    chatRoomId: ''
-  },
+  initialState,
   reducers: {
     setChatRooms: (state, { payload }) => {
       // eslint-disable-next-line no-param-reassign

--- a/src/reducers/migrations.js
+++ b/src/reducers/migrations.js
@@ -1,0 +1,7 @@
+import { initialState as chatInitialState } from 'reducers/ChatDux';
+
+const migrations = {
+  0: _previousVersionState => ({ chat: chatInitialState })
+};
+
+export default migrations;


### PR DESCRIPTION
Not sure if we should even be persisting chat messages themselves, but for now update redux persist to migrate to new architecture.