### PR TITLE
feat(Socket): add socket listeners and skeleton redux actions for chat offers

### DIFF
--- a/src/constants/socket.js
+++ b/src/constants/socket.js
@@ -1,7 +1,13 @@
 export const EMIT_CHAT_ROOMS = 'req_chat_rooms';
 export const EMIT_CONVERSATION = 'req_conversation';
 export const EMIT_NEW_MESSAGE = 'req_new_message';
+export const EMIT_NEW_OFFER = 'req_new_offer';
+export const EMIT_ACCEPT_OFFER = 'req_accept_offer';
+export const EMIT_DECLINE_OFFER = 'req_decline_offer';
 
 export const RECEIVE_CHAT_ROOMS = 'res_chat_rooms';
 export const RECEIVE_CONVERSATION = 'res_conversation';
 export const RECEIVE_NEW_MESSAGE = 'res_new_message';
+export const RECEIVE_NEW_OFFER = 'res_new_offer';
+export const RECEIVE_ACCEPT_OFFER = 'res_accept_offer';
+export const RECEIVE_DECLINE_OFFER = 'res_decline_offer';

--- a/src/reducers/ChatDux.js
+++ b/src/reducers/ChatDux.js
@@ -32,6 +32,15 @@ const chat = createSlice({
       state.chatRooms.splice(index, 1, payload);
       // eslint-disable-next-line no-param-reassign
       state.chatRooms = _orderBy(state.chatRooms, ['createdAt'], ['desc']);
+    },
+    addNewOffer: () => {
+      // TODO: add to new message in chatConversation.conversation
+    },
+    acceptOffer: () => {
+      // TODO: set offer message in chatConversation.conversation to ACCEPTED
+    },
+    declineOffer: () => {
+      // TODO: set offer message in chatConversation.conversation to REJECTED
     }
   }
 });
@@ -39,7 +48,10 @@ const chat = createSlice({
 export const {
   setChatRooms,
   setChatConversation,
-  addNewMessage
+  addNewMessage,
+  addNewOffer,
+  acceptOffer,
+  declineOffer
 } = chat.actions;
 
 export default chat.reducer;

--- a/src/services/SocketService/socketRequestService.js
+++ b/src/services/SocketService/socketRequestService.js
@@ -10,6 +10,17 @@ import {
   EMIT_DECLINE_OFFER
 } from 'constants/socket';
 
+/**
+ * Emit event to get a list of chat rooms.
+ * Example:
+ * {
+ *  "token": "...",
+ *  "user_type": "buyer",
+ *  "is_archived": false
+ * }
+ * @param socket
+ * @param userType
+ */
 const getChatRooms = ({ socket, userType }) => {
   socket.emit(
     EMIT_CHAT_ROOMS,
@@ -20,6 +31,16 @@ const getChatRooms = ({ socket, userType }) => {
   );
 };
 
+/**
+ * Emit event to get conversation for a chat room.
+ * Example:
+ * {
+ *  "token": "...",
+ *  "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394"
+ * }
+ * @param chatRoomId
+ * @param socket
+ */
 const getChatConversation = ({ chatRoomId, socket }) => {
   socket.emit(
     EMIT_CONVERSATION,
@@ -30,6 +51,18 @@ const getChatConversation = ({ chatRoomId, socket }) => {
   );
 };
 
+/**
+ * Emit event to add new message.
+ * Example:
+ * {
+ *  "token": "...",
+ *  "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
+ *  "message": "hello world"
+ * }
+ * @param chatRoomId
+ * @param message
+ * @param socket
+ */
 const addNewMessage = ({ chatRoomId, message, socket }) => {
   socket.emit(
     EMIT_NEW_MESSAGE,
@@ -41,6 +74,22 @@ const addNewMessage = ({ chatRoomId, message, socket }) => {
   );
 };
 
+/**
+ * Emit event to add new offer.
+ * Example:
+ * {
+ *  "token": "...",
+ *  "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
+ *  "price": "5",
+ *  "number_of_shares": "100",
+ *  "user_type": "buyer"
+ * }
+ * @param chatRoomId
+ * @param price
+ * @param numberOfShares
+ * @param userType
+ * @param socket
+ */
 const addNewOffer = ({
   chatRoomId,
   price,
@@ -60,6 +109,20 @@ const addNewOffer = ({
   );
 };
 
+/**
+ * Emit event to accept offer. // TODO: Does not change offer to accepted
+ * Example:
+ * {
+ *  "token": "AQV6I_qG1FzpD0ECYG9WpVXaZYIpFSZHeqNWyqKfKRFuRR8AQbfSxDIi8ux2GzdpSX28q-AEpDF2XgtlPlZC9GpKU_ldKWrXP_hrN1zLHMyarFx9NpajK-2pSV-_DNHWiHXSGWSHf8o2u7I_AE3_FLWEQGFEs9jrGsLgndZURaqAvb3WZZQiDoQpgCw5uMOpVx6p_rf9yE8qrTzYtzsAxJ_gPGMweL3jJQLq0nTuAS9qV8TJCg-Otfkj5yA-sTR5GbsV0vSzUZ6xJqa5atdA_HaRTrkcvJ2Y1GePeGsY76b4m09OYSXY3BTqkglcPu4NcMii9GjILZpICA1tM1C_o4T_lWSEDw",
+ *  "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
+ *  "user_type": "buyer",
+ *  "offer_id": "fac16c9e-0928-4c53-b3df-d84ebf229ee0"
+ * }
+ * @param chatRoomId
+ * @param offerId
+ * @param userType
+ * @param socket
+ */
 const acceptOffer = ({ chatRoomId, offerId, userType, socket }) => {
   socket.emit(
     EMIT_ACCEPT_OFFER,
@@ -72,6 +135,20 @@ const acceptOffer = ({ chatRoomId, offerId, userType, socket }) => {
   );
 };
 
+/**
+ * Emit event to decline offer.
+ * Example:
+ * {
+ *  "token": "..."
+ *  "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
+ *  "user_type": "buyer",
+ *  "offer_id": "9b4638c4-e2a2-48ce-aafe-995a158f4fbf"
+ * }
+ * @param chatRoomId
+ * @param offerId
+ * @param userType
+ * @param socket
+ */
 const declineOffer = ({ chatRoomId, offerId, userType, socket }) => {
   socket.emit(
     EMIT_DECLINE_OFFER,

--- a/src/services/SocketService/socketRequestService.js
+++ b/src/services/SocketService/socketRequestService.js
@@ -4,7 +4,10 @@ import tokenUtils from 'utils/tokenUtils';
 import {
   EMIT_CHAT_ROOMS,
   EMIT_CONVERSATION,
-  EMIT_NEW_MESSAGE
+  EMIT_NEW_MESSAGE,
+  EMIT_NEW_OFFER,
+  EMIT_ACCEPT_OFFER,
+  EMIT_DECLINE_OFFER
 } from 'constants/socket';
 
 const getChatRooms = ({ socket, userType }) => {
@@ -38,8 +41,54 @@ const addNewMessage = ({ chatRoomId, message, socket }) => {
   );
 };
 
+const addNewOffer = ({
+  chatRoomId,
+  price,
+  numberOfShares,
+  userType,
+  socket
+}) => {
+  socket.emit(
+    EMIT_NEW_OFFER,
+    snakecaseKeys({
+      token: tokenUtils.getToken(),
+      price,
+      numberOfShares,
+      userType,
+      chatRoomId
+    })
+  );
+};
+
+const acceptOffer = ({ chatRoomId, offerId, userType, socket }) => {
+  socket.emit(
+    EMIT_ACCEPT_OFFER,
+    snakecaseKeys({
+      token: tokenUtils.getToken(),
+      offerId,
+      userType,
+      chatRoomId
+    })
+  );
+};
+
+const declineOffer = ({ chatRoomId, offerId, userType, socket }) => {
+  socket.emit(
+    EMIT_DECLINE_OFFER,
+    snakecaseKeys({
+      token: tokenUtils.getToken(),
+      offerId,
+      userType,
+      chatRoomId
+    })
+  );
+};
+
 export default {
   getChatRooms,
   getChatConversation,
-  addNewMessage
+  addNewMessage,
+  addNewOffer,
+  acceptOffer,
+  declineOffer
 };

--- a/src/services/SocketService/socketRequestService.js
+++ b/src/services/SocketService/socketRequestService.js
@@ -113,7 +113,7 @@ const addNewOffer = ({
  * Emit event to accept offer. // TODO: Does not change offer to accepted
  * Example:
  * {
- *  "token": "AQV6I_qG1FzpD0ECYG9WpVXaZYIpFSZHeqNWyqKfKRFuRR8AQbfSxDIi8ux2GzdpSX28q-AEpDF2XgtlPlZC9GpKU_ldKWrXP_hrN1zLHMyarFx9NpajK-2pSV-_DNHWiHXSGWSHf8o2u7I_AE3_FLWEQGFEs9jrGsLgndZURaqAvb3WZZQiDoQpgCw5uMOpVx6p_rf9yE8qrTzYtzsAxJ_gPGMweL3jJQLq0nTuAS9qV8TJCg-Otfkj5yA-sTR5GbsV0vSzUZ6xJqa5atdA_HaRTrkcvJ2Y1GePeGsY76b4m09OYSXY3BTqkglcPu4NcMii9GjILZpICA1tM1C_o4T_lWSEDw",
+ *  "token": "...",
  *  "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
  *  "user_type": "buyer",
  *  "offer_id": "fac16c9e-0928-4c53-b3df-d84ebf229ee0"

--- a/src/services/SocketService/socketResponseService.js
+++ b/src/services/SocketService/socketResponseService.js
@@ -17,6 +17,23 @@ import {
   RECEIVE_DECLINE_OFFER
 } from 'constants/socket';
 
+/**
+ * Receives a list of chat rooms.
+ * Example:
+ * [
+ *  {
+ *   "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
+ *   "friendly_name": "Jasmine heron 2740",
+ *   "is_deal_closed": false,
+ *   "seller_price": 10,
+ *   "seller_number_of_shares": 400,
+ *   "buyer_price": 10,
+ *   "buyer_number_of_shares": 100,
+ *   "updated_at": 1573225975481.102
+ *  }
+ * ]
+ * @param socket
+ */
 export const setChatRoomsListener = socket => {
   socket.on(RECEIVE_CHAT_ROOMS, payload => {
     store.dispatch(
@@ -27,6 +44,38 @@ export const setChatRoomsListener = socket => {
   });
 };
 
+/**
+ * Receives the conversation for a chat room.
+ * Example:
+ * {
+ * "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
+ * "seller_price": 10,
+ * "seller_number_of_shares": 400,
+ * "buyer_price": 10,
+ * "buyer_number_of_shares": 100,
+ * "updated_at": 1573228223507.107,
+ * "is_deal_closed": false,
+ * "conversation": [
+ *   {
+ *     "id": "6f45cd6d-0198-4360-ad50-889d1749e435",
+ *     "message": "hello world",
+ *     "created_at": 1573227977677.968,
+ *     "user_type": "buyer",
+ *     "type": "message"
+ *   },
+ *   {
+ *     "id": "9b4638c4-e2a2-48ce-aafe-995a158f4fbf",
+ *     "price": 5,
+ *     "number_of_shares": 100,
+ *     "offer_status": "PENDING",
+ *     "created_at": 1573228223507.107,
+ *     "user_type": "buyer",
+ *     "type": "offer"
+ *   }
+ *  ]
+ * }
+ * @param socket
+ */
 export const setChatConversationListener = socket => {
   socket.on(RECEIVE_CONVERSATION, payload => {
     store.dispatch(
@@ -37,6 +86,22 @@ export const setChatConversationListener = socket => {
   });
 };
 
+/**
+ * Receives new message.
+ * Example:
+ * {
+ * "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
+ * "updated_at": 1573228653301.362,
+ * "new_chat": {
+ *   "id": "5fa9142b-db46-49d2-91ff-03488b1e9337",
+ *   "message": "hello world",
+ *   "created_at": 1573228653301.362,
+ *   "user_type": "buyer",
+ *   "type": "message"
+ *  }
+ * }
+ * @param socket
+ */
 export const addNewMessageListener = socket => {
   socket.on(RECEIVE_NEW_MESSAGE, payload => {
     store.dispatch(
@@ -47,6 +112,26 @@ export const addNewMessageListener = socket => {
   });
 };
 
+/**
+ * Receives new offer.
+ * Example:
+ * {
+ *  "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
+ *  "updated_at": 1573228223507.107,
+ *  "new_chat": {
+ *   "id": "9b4638c4-e2a2-48ce-aafe-995a158f4fbf",
+ *   "price": 5,
+ *   "number_of_shares": 100,
+ *   "offer_status": "PENDING",
+ *   "created_at": 1573228223507.107,
+ *   "user_type": "buyer",
+ *   "type": "offer"
+ *  },
+ *  "is_deal_closed": false
+ * }
+ *
+ * @param socket
+ */
 export const addNewOfferListener = socket => {
   socket.on(RECEIVE_NEW_OFFER, payload => {
     store.dispatch(
@@ -57,6 +142,26 @@ export const addNewOfferListener = socket => {
   });
 };
 
+/**
+ * Receives offer accepted.
+ * Example:
+ * {
+ *  "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
+ *  "updated_at": 1573229085411.719,
+ *  "new_chat": {
+ *    "id": "fac16c9e-0928-4c53-b3df-d84ebf229ee0",
+ *    "price": 5,
+ *    "number_of_shares": 2000,
+ *    "offer_status": "PENDING",
+ *    "created_at": 1573229085411.719,
+ *    "user_type": "buyer",
+ *    "type": "offer"
+ *  },
+ *  "is_deal_closed": false
+ * }
+ *
+ * @param socket
+ */
 export const acceptOfferListener = socket => {
   socket.on(RECEIVE_ACCEPT_OFFER, payload => {
     store.dispatch(
@@ -67,6 +172,25 @@ export const acceptOfferListener = socket => {
   });
 };
 
+/**
+ * Receives declined offer.
+ * Example:
+ * {
+ *  "chat_room_id": "4db2a763-bdb3-45b6-af8d-7944af8b1394",
+ *  "updated_at": 1573228223507.107,
+ *  "new_chat": {
+ *   "id": "9b4638c4-e2a2-48ce-aafe-995a158f4fbf",
+ *   "price": 5,
+ *   "number_of_shares": 100,
+ *   "offer_status": "REJECTED",
+ *   "created_at": 1573228223507.107,
+ *   "user_type": "buyer",
+ *   "type": "offer"
+ *  },
+ *  "is_deal_closed": false
+ * }
+ * @param socket
+ */
 export const declineOfferListener = socket => {
   socket.on(RECEIVE_DECLINE_OFFER, payload => {
     store.dispatch(

--- a/src/services/SocketService/socketResponseService.js
+++ b/src/services/SocketService/socketResponseService.js
@@ -3,12 +3,18 @@ import store from 'app/store';
 import {
   setChatRooms,
   setChatConversation,
-  addNewMessage
+  addNewMessage,
+  addNewOffer,
+  acceptOffer,
+  declineOffer
 } from 'reducers/ChatDux';
 import {
   RECEIVE_CHAT_ROOMS,
   RECEIVE_CONVERSATION,
-  RECEIVE_NEW_MESSAGE
+  RECEIVE_NEW_MESSAGE,
+  RECEIVE_NEW_OFFER,
+  RECEIVE_ACCEPT_OFFER,
+  RECEIVE_DECLINE_OFFER
 } from 'constants/socket';
 
 export const setChatRoomsListener = socket => {
@@ -41,10 +47,43 @@ export const addNewMessageListener = socket => {
   });
 };
 
+export const addNewOfferListener = socket => {
+  socket.on(RECEIVE_NEW_OFFER, payload => {
+    store.dispatch(
+      addNewOffer({
+        ...camelcaseKeys(payload, { deep: true })
+      })
+    );
+  });
+};
+
+export const acceptOfferListener = socket => {
+  socket.on(RECEIVE_ACCEPT_OFFER, payload => {
+    store.dispatch(
+      acceptOffer({
+        ...camelcaseKeys(payload, { deep: true })
+      })
+    );
+  });
+};
+
+export const declineOfferListener = socket => {
+  socket.on(RECEIVE_DECLINE_OFFER, payload => {
+    store.dispatch(
+      declineOffer({
+        ...camelcaseKeys(payload, { deep: true })
+      })
+    );
+  });
+};
+
 const initialize = socket => {
   setChatRoomsListener(socket);
   setChatConversationListener(socket);
   addNewMessageListener(socket);
+  addNewOfferListener(socket);
+  acceptOfferListener(socket);
+  declineOfferListener(socket);
 };
 
 export default {


### PR DESCRIPTION
…to socket services

This patch allow socket events to accept offer, create offer, and decline offer. The redux
action has also been created. TODOs are added to show what is suppose to happen when data
is received from socketEvent.

Note that the redux actions created do not do anything at the moment. The socket services
are setup with the correct parameters.